### PR TITLE
Added 'SFX' type for UCSF XML Search feed

### DIFF
--- a/library_collection/models.py
+++ b/library_collection/models.py
@@ -77,6 +77,7 @@ class Collection(models.Model):
             ('MRC', 'MARC21'),
             ('NUX', 'Shared DAMS'),
             ('ALX', 'Aleph MARC XML'),
+            ('SFX', 'UCSF XML Search Results (tobacco)'),
             ('TBD', 'Harvest type TBD'),
     )
     harvest_type = models.CharField(max_length=3, choices=HARVEST_TYPE_CHOICES, default='X')

--- a/library_collection/util/enrichments_item_oai.txt
+++ b/library_collection/util/enrichments_item_oai.txt
@@ -5,6 +5,7 @@
 /move_date_values?prop=sourceResource%2Fspatial,
 /shred?prop=sourceResource%2Fspatial&delim=--,
 /enrich-subject,
+/enrich_earliest_date,
 /enrich_date,
 /enrich-type,
 /enrich-format,


### PR DESCRIPTION
One line change to add harvest type for UCSF xml search feed.