### PR TITLE
Private site

### DIFF
--- a/collection_registry/middleware/remoteuser_mock.py
+++ b/collection_registry/middleware/remoteuser_mock.py
@@ -9,7 +9,7 @@ except AttributeError:
 try:
     paths_locked = settings.REMOTE_USER_MOCK_PATHS
 except AttributeError:
-    paths_locked = ['/edit', '/admin']
+    paths_locked = ['/edit', '/admin', '/api']
 
 # https://docs.djangoproject.com/en/2.2/topics/http/middleware/#upgrading-middleware
 class RemoteUserMockMiddleware(MiddlewareMixin):

--- a/collection_registry/settings.py
+++ b/collection_registry/settings.py
@@ -183,6 +183,7 @@ INSTALLED_APPS = (
     'django_json_widget',
     # 'rest_framework',
     #'dbdump',
+    'tastypie',
 )
 
 ALLOWED_HOSTS = ['dsc-registry2-dev.cdlib.org', 'localhost', '127.0.0.1']

--- a/collection_registry/urls.py
+++ b/collection_registry/urls.py
@@ -1,18 +1,14 @@
 # urls.py
 from django.conf.urls import include, url
 from library_collection.models import Collection, Campus
+from library_collection import views
 
-# Uncomment the next two lines to enable the admin:
 from django.contrib import admin
 from django.contrib.auth.views import LoginView
 from django.contrib.sitemaps import views as sitemaps_views
-# from ajax_select import urls as ajax_select_urls
 from django.contrib.sitemaps import GenericSitemap
-# http://stackoverflow.com/questions/11428427/no-module-named-simple-error-in-django
-# from django.views.generic.simple import redirect_to
-#from some_app.views import AboutView
 from django.views.generic import TemplateView
-# from exhibits.views import calCultures
+from library_collection.api import v1_api
 
 admin.autodiscover()
 
@@ -30,13 +26,12 @@ sitemaps = {
 }
 
 urlpatterns = [
+    url(r'^$', views.about, name='about'),
     url(r'^robots.txt', TemplateView.as_view(template_name="robots.txt", content_type="text/plain"), name="robots"),
-    # url(r'^exhibitions/', include('exhibits.urls', namespace="exhibits")),
+    url(r'^api/', include(v1_api.urls)),
     url(r'^oai/', include('oai.urls', namespace="oai")),
-    # url(r'^for-educators/', include(('exhibits.teacher_urls', 'for-teachers'), namespace="for-teachers")),
-    # url(r'^cal-cultures/', calCultures, name="cal-cultures"),
     url(r'^admin/', admin.site.urls),
     url(r'^accounts/login/', LoginView.as_view(), name='login'),
     url(r'^sitemap\.xml$', sitemaps_views.sitemap, {'sitemaps': sitemaps}, name='sitemap'),
-    url(r'^', include('library_collection.urls'), name='registry'),
+    url(r'^edit/', include('library_collection.urls'), name='registry'),
 ]

--- a/httpd/httpd.conf.prod
+++ b/httpd/httpd.conf.prod
@@ -184,6 +184,12 @@ Listen 18443
         require valid-user
     </Location>
 
+    <LocationMatch "/api(/|$)">
+        AuthType shibboleth
+        ShibRequestSetting requireSession Off
+        Require shibboleth
+    </LocationMatch>
+
     <Location /Shibboleth.sso> 
         SetHandler default-handler 
     </Location> 

--- a/httpd/httpd.conf.stage
+++ b/httpd/httpd.conf.stage
@@ -184,6 +184,12 @@ Listen 18443
         require valid-user
     </Location>
 
+    <LocationMatch "/api(/|$)">
+        AuthType shibboleth
+        ShibRequestSetting requireSession Off
+        Require shibboleth
+    </LocationMatch>
+
     <Location /Shibboleth.sso> 
         SetHandler default-handler 
     </Location> 

--- a/library_collection/api.py
+++ b/library_collection/api.py
@@ -1,17 +1,22 @@
 from tastypie import fields
 from tastypie.resources import ModelResource
 from tastypie.serializers import Serializer
-from tastypie.authentication import ApiKeyAuthentication as Authentication
+from tastypie.authentication import ApiKeyAuthentication, SessionAuthentication, MultiAuthentication
 from tastypie.authorization import ReadOnlyAuthorization
 from library_collection.models import Collection, Campus, Repository
 from library_collection.models import CollectionCustomFacet
 from tastypie.constants import ALL
 from tastypie.api import Api
 
+default_authentication = MultiAuthentication(
+    ApiKeyAuthentication(),
+    SessionAuthentication()
+)
+
 class CampusResource(ModelResource):
     class Meta:
         queryset = Campus.objects.all()
-        authentication = Authentication()
+        authentication = default_authentication
         authorization = ReadOnlyAuthorization()
 
 
@@ -19,7 +24,7 @@ class RepositoryResource(ModelResource):
     campus = fields.ToManyField(CampusResource, 'campus', full=True)
     class Meta:
         queryset = Repository.objects.all()
-        authentication = Authentication()
+        authentication = default_authentication
         authorization = ReadOnlyAuthorization()
 
 
@@ -31,7 +36,7 @@ class CollectionResource(ModelResource):
 
     class Meta:
         queryset = Collection.objects.all()
-        authentication = Authentication()
+        authentication = default_authentication
         authorization = ReadOnlyAuthorization()
         serializer = Serializer(formats=['json', 'jsonp', 'xml', 'yaml', 'plist'])
         filtering = {
@@ -76,7 +81,7 @@ class RikoltiCollectionResource(CollectionResource):
 
     class Meta:
         queryset = Collection.objects.all()
-        authentication = Authentication()
+        authentication = default_authentication
         list_allowed_methods = ['get']
         filtering = rikolti_filters
         excludes = rikolti_excludes
@@ -101,7 +106,7 @@ class RikoltiMapperResource(RikoltiCollectionResource):
 class RikoltiFetcherResource(RikoltiCollectionResource):
     class Meta:
         queryset = Collection.objects.all()
-        authentication = Authentication()
+        authentication = default_authentication
         list_allowed_methods = ['get']
         filtering = rikolti_filters
         excludes = (
@@ -116,7 +121,7 @@ class CustomFacetResource(ModelResource):
 
     class Meta:
         queryset = CollectionCustomFacet.objects.all()
-        authentication = Authentication()
+        authentication = default_authentication
         authorization = ReadOnlyAuthorization()
         resource_name = 'custom_facet'
 

--- a/library_collection/api.py
+++ b/library_collection/api.py
@@ -1,7 +1,7 @@
 from tastypie import fields
 from tastypie.resources import ModelResource
 from tastypie.serializers import Serializer
-from tastypie.authentication import Authentication
+from tastypie.authentication import ApiKeyAuthentication as Authentication
 from tastypie.authorization import ReadOnlyAuthorization
 from library_collection.models import Collection, Campus, Repository
 from library_collection.models import CollectionCustomFacet
@@ -76,6 +76,7 @@ class RikoltiCollectionResource(CollectionResource):
 
     class Meta:
         queryset = Collection.objects.all()
+        authentication = Authentication()
         list_allowed_methods = ['get']
         filtering = rikolti_filters
         excludes = rikolti_excludes
@@ -100,6 +101,7 @@ class RikoltiMapperResource(RikoltiCollectionResource):
 class RikoltiFetcherResource(RikoltiCollectionResource):
     class Meta:
         queryset = Collection.objects.all()
+        authentication = Authentication()
         list_allowed_methods = ['get']
         filtering = rikolti_filters
         excludes = (

--- a/library_collection/api.py
+++ b/library_collection/api.py
@@ -5,8 +5,8 @@ from tastypie.authentication import Authentication
 from tastypie.authorization import ReadOnlyAuthorization
 from library_collection.models import Collection, Campus, Repository
 from library_collection.models import CollectionCustomFacet
-from tastypie.constants import ALL, ALL_WITH_RELATIONS
-
+from tastypie.constants import ALL
+from tastypie.api import Api
 
 class CampusResource(ModelResource):
     class Meta:
@@ -117,3 +117,11 @@ class CustomFacetResource(ModelResource):
         authentication = Authentication()
         authorization = ReadOnlyAuthorization()
         resource_name = 'custom_facet'
+
+v1_api = Api(api_name='v1')
+v1_api.register(CollectionResource())
+v1_api.register(CampusResource())
+v1_api.register(RepositoryResource())
+v1_api.register(RikoltiCollectionResource())
+v1_api.register(RikoltiFetcherResource())
+v1_api.register(RikoltiMapperResource())

--- a/library_collection/context_processors.py
+++ b/library_collection/context_processors.py
@@ -5,11 +5,13 @@ def active_tab(request):
     Return a key for the active tab into the default template context
     by parsing the request.path
     '''
-    tab = 'collection'
+    tab = ''
+    if 'about' in request.path or request.path == '/':
+        tab = 'about'
+    if 'collection' in request.path:
+        tab = 'collection'
     if "repositor" in request.path:
         tab = 'repositories'
-    if "about" in request.path:
-        tab = 'about'
     if "exhibitions" in request.path or "educators" in request.path:
         tab = 'exhibitions'
     return {

--- a/library_collection/context_processors.py
+++ b/library_collection/context_processors.py
@@ -6,7 +6,7 @@ def active_tab(request):
     by parsing the request.path
     '''
     tab = ''
-    if 'about' in request.path or request.path == '/':
+    if 'about' in request.path or request.path in ['/', '/edit/']:
         tab = 'about'
     if 'collection' in request.path:
         tab = 'collection'

--- a/library_collection/templates/library_collection/_navbar_campus.html
+++ b/library_collection/templates/library_collection/_navbar_campus.html
@@ -12,38 +12,20 @@
             <ul class="list-group" style="margin: 0px">
               {% for campus_iter in campuses %}
               <li class="list-group-item{% if campus_iter == campus %} list-group-item-secondary{% endif %}" style="width: 100%">
-                {% if user.is_authenticated and editing %}
-                  {% if campus_iter == campus %}
-                    <a href="{% url edit_this %}">
-                      <div class="row-fluid">
-                        <div class="float-left"><span class="icon-remove" style="margin-right: .75em;">X</span></div>
-                        <div style="overflow: hidden; ">{{ campus_iter.name }}</div>
-                      </div>
-                    </a>
-                  {% else %}
-                    <a href="{% url edit_this campus_slug=campus_iter.slug %}">
-                      <div class="row-fluid">
-                        <div class="float-left"><span class="icon-remove" style="visibility:hidden; margin-left: .75em">X</span></div>
-                        <div style="overflow: hidden;">{{ campus_iter.name }}</div>
-                      </div>
-                    </a>
-                  {% endif %}
+                {% if campus_iter == campus %}
+                  <a href="{% url this %}">
+                    <div class="row-fluid">
+                      <div class="float-left"><span class="icon-remove" style="margin-right: .75em;">X</span></div>
+                      <div style="overflow: hidden; ">{{ campus_iter.name }}</div>
+                    </div>
+                  </a>
                 {% else %}
-                  {% if campus_iter == campus %}
-                    <a href="{% url this %}">
-                      <div class="row-fluid">
-                        <div class="float-left"><span class="icon-remove" style="margin-right: .75em;">X</span></div>
-                        <div style="overflow: hidden; ">{{ campus_iter.name }}</div>
-                      </div>
-                    </a>
-                  {% else %}
-                    <a href="{% url this campus_slug=campus_iter.slug %}">
-                      <div class="row-fluid">
-                        <div class="float-left"><span class="icon-remove" style="visibility:hidden; margin-left: .75em">X</span></div>
-                        <div style="overflow: hidden;">{{ campus_iter.name }}</div>
-                      </div>
-                    </a>
-                  {% endif %}
+                  <a href="{% url this campus_slug=campus_iter.slug %}">
+                    <div class="row-fluid">
+                      <div class="float-left"><span class="icon-remove" style="visibility:hidden; margin-left: .75em">X</span></div>
+                      <div style="overflow: hidden;">{{ campus_iter.name }}</div>
+                    </div>
+                  </a>
                 {% endif %}
               </li>
               {% endfor %}

--- a/library_collection/templates/library_collection/_navbar_harvest_type2.html
+++ b/library_collection/templates/library_collection/_navbar_harvest_type2.html
@@ -21,7 +21,6 @@
                       </div>
                     </a>
                   {% else %}
-                    <!-- a href="{ % url this %}?harvest_type={{ type.0 }}" -->
                     <a href="?harvest_type={{ type.0 }}">
                       <div class="row-fluid">
                         <div class="float-left"><span class="icon-remove" style="visibility:hidden; margin-left: .75em">X</span></div>

--- a/library_collection/templates/library_collection/about.html
+++ b/library_collection/templates/library_collection/about.html
@@ -5,11 +5,11 @@
   <div class="col-10" style="line-height:25px">
     <div class="card bg-light">
       <div class="card-body">
-    <p>
+    <h1>
       Welcome to the Calisphere Collection Registry.
-    </p>
+    </h1>
     
-    <h4>About the Registry</h4>
+    <h2>About the Registry</h2>
     <p>
       The Collection Registry is an administrative interface (requires login)used by CDL staff to orchestrate harvesting* of digital collections for publication in the Calisphere website. The Collection Registry contains basic information about the collection (such as title and description) that displays in Calisphere. 
     </p>
@@ -23,7 +23,7 @@
       <b><a href="{% url 'login' %}">Login (UC Single Sign-On)</a></b>
     </p>
     
-    <h4>Terms of use</h4>
+    <h2>Terms of use</h2>
     <p>
       Access to the Registry is restricted to CDL staff and designated University of California library/department digital collection administrators. 
     </p>    

--- a/library_collection/templates/library_collection/about.html
+++ b/library_collection/templates/library_collection/about.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="row">
-  <div class="col-10" style="line-height:25px">
+  <div class="col-lg-10" style="line-height:25px">
     <div class="card bg-light">
       <div class="card-body">
     <h1>

--- a/library_collection/templates/library_collection/about.html
+++ b/library_collection/templates/library_collection/about.html
@@ -6,35 +6,27 @@
     <div class="card bg-light">
       <div class="card-body">
     <p>
-      Welcome to the Collection Registry for the UC Libraries Digital Collection (UCLDC)!
+      Welcome to the Calisphere Collection Registry.
     </p>
     
-    <h4>What it is</h4>
+    <h4>About the Registry</h4>
     <p>
-      The Collection Registry is a key component of the UCLDC that will enable campus library staff to:
+      The Collection Registry is an administrative interface (requires login)used by CDL staff to orchestrate harvesting* of digital collections for publication in the Calisphere website. The Collection Registry contains basic information about the collection (such as title and description) that displays in Calisphere. 
     </p>
-    
-    <ol style="margin-left:40px">
-      <li style="line-height:25px">
-        Create information that will be displayed in the UCLDC’s public interface, for example as facets.
-      </li>
-      <li style="line-height:25px">
-        Track the status of digital collections slated for the UCLDC, for example by indicating the location of collections ready for harvest.
-      </li>
-      <li style="line-height:25px">
-        Engage in collaborative digital collection development and/or digitization planning.
-      </li>
-    </ol>
+    <p>
+      Staff at University of California campus libraries/departments  may request login access to the Collection Registry, so that campus digital collection administrators may manage collection details, such as collection titles and descriptions. Please <a href="https://help.oac.cdlib.org/support/tickets/new">contact us</a> to request an account.
+    </p>
+    <p>
+      *Calisphere is based on a harvest model, where the CDL retrieves item records (metadata and associated thumbnails) from each contributors’ digital collections platforms. Setting up the harvesting process requires some initial setup at the beginning, so that the CDL can establish a connection with a given digital collections platform. Learn more about our process for <a href="https://help.oac.cdlib.org/support/solutions/9000115811">harvesting collections to Calisphere</a>.
+    </p>
+    <p>
+      <b><a href="{% url 'login' %}">Login (UC Single Sign-On)</a></b>
+    </p>
     
     <h4>Terms of use</h4>
     <p>
-      This interface is under development, as part of the broader implementation of the UCLDC. At this time, parts of this site are limited to our project collaborators. Use of the site by other individuals is restricted to viewing this web interface.
-    </p>
-    
-    <h4>Learn more</h4>
-    <p>
-      We welcome your feedback! Please report any bugs, questions, or ideas to <a href="mailto:oacops@cdlib.org">oacops@cdlib.org</a>. For more information about the UCLDC and the Implementation Project, visit our project <a href="https://wiki.library.ucsf.edu/display/UCLDC/UCLDC+Implementation">wiki</a>.
-    </p>
+      Access to the Registry is restricted to CDL staff and designated University of California library/department digital collection administrators. 
+    </p>    
   </div>
 </div>
   </div>

--- a/library_collection/templates/library_collection/about.html
+++ b/library_collection/templates/library_collection/about.html
@@ -20,7 +20,7 @@
       *Calisphere is based on a harvest model, where the CDL retrieves item records (metadata and associated thumbnails) from each contributors’ digital collections platforms. Setting up the harvesting process requires some initial setup at the beginning, so that the CDL can establish a connection with a given digital collections platform. Learn more about our process for <a href="https://help.oac.cdlib.org/support/solutions/9000115811">harvesting collections to Calisphere</a>.
     </p>
     <p>
-      <b><a href="{% url 'login' %}">Login (UC Single Sign-On)</a></b>
+      <b><a href="{% url 'collections' %}">Login (UC Single Sign-On)</a></b>
     </p>
     
     <h2>Terms of use</h2>

--- a/library_collection/templates/library_collection/about.html
+++ b/library_collection/templates/library_collection/about.html
@@ -11,7 +11,7 @@
     
     <h2>About the Registry</h2>
     <p>
-      The Collection Registry is an administrative interface (requires login)used by CDL staff to orchestrate harvesting* of digital collections for publication in the Calisphere website. The Collection Registry contains basic information about the collection (such as title and description) that displays in Calisphere. 
+      The Collection Registry is an administrative interface (requires login) used by CDL staff to orchestrate harvesting* of digital collections for publication in the Calisphere website. The Collection Registry contains basic information about the collection (such as title and description) that displays in Calisphere. 
     </p>
     <p>
       Staff at University of California campus libraries/departments  may request login access to the Collection Registry, so that campus digital collection administrators may manage collection details, such as collection titles and descriptions. Please <a href="https://help.oac.cdlib.org/support/tickets/new">contact us</a> to request an account.

--- a/library_collection/templates/library_collection/collection.html
+++ b/library_collection/templates/library_collection/collection.html
@@ -92,7 +92,7 @@
       {% if edit == "true" %}
         <br><button type="submit" name="submit" form="edit_collection_detail">Save</button>
       {% else %}
-        <form action="{% url 'edit_detail' colid=collection.id col_slug=collection.slug %}" method="post">
+        <form action="{% url 'detail' colid=collection.id col_slug=collection.slug %}" method="post">
           {% csrf_token %}
           <button type="submit" name="edit" value="true" class="btn btn-secondary"><i class="icon-edit"></i> Edit this collection</button>
         </form>

--- a/library_collection/templates/library_collection/collection_edit.html
+++ b/library_collection/templates/library_collection/collection_edit.html
@@ -11,9 +11,9 @@
   <div class="card bg-light">
   <div class="card-body">
     {% if edit %}
-    <form action="{% url 'edit_detail' colid=collection.id col_slug=collection.slug %}" method="post" id="edit_collection_detail">
+    <form action="{% url 'detail' colid=collection.id col_slug=collection.slug %}" method="post" id="edit_collection_detail">
     {% elif new %}
-    <form action="{% url 'edit_collections' %}" method="post" id="new_collection">
+    <form action="{% url 'collections' %}" method="post" id="new_collection">
     {% endif %}
       {% csrf_token %}
       <div class="form-group">
@@ -111,9 +111,9 @@
 
       <button type="submit" class="btn btn-primary"><i class="icon-ok icon-white"></i> Save</button>
       {% if edit %}
-      <a href="{% url 'edit_detail' colid=collection.id col_slug=collection.slug %}" class="btn btn-secondary"><i class="icon-ban-circle"></i> Cancel</a>
+      <a href="{% url 'detail' colid=collection.id col_slug=collection.slug %}" class="btn btn-secondary"><i class="icon-ban-circle"></i> Cancel</a>
       {% elif new %}
-      <a href="{% url 'edit_collections' %}" class="btn btn-secondary"><i class="icon-ban-circle"></i> Cancel</a>
+      <a href="{% url 'collections' %}" class="btn btn-secondary"><i class="icon-ban-circle"></i> Cancel</a>
       {% endif %}
 
       

--- a/library_collection/templates/library_collection/collection_list.html
+++ b/library_collection/templates/library_collection/collection_list.html
@@ -37,12 +37,10 @@
         </form>
       </div>
       <div class="col-sm-auto mb-3">
-        {% if user.is_authenticated and editing %}
-            <form action="{% url 'edit_collections' %}" method="post" class="form-inline">
-              {% csrf_token %}
-              <button type="submit" name="new" value="true" class="btn btn-secondary"><i class="icon-plus"></i> Add new Collection</button>
-            </form>
-        {% endif %}
+          <form action="{% url 'collections' %}" method="post" class="form-inline">
+            {% csrf_token %}
+            <button type="submit" name="new" value="true" class="btn btn-secondary"><i class="icon-plus"></i> Add new Collection</button>
+          </form>
       </div>
     </div>
 
@@ -53,11 +51,7 @@
         {% for collection in collections %}
         <tr>
           <td>
-            {% if user.is_authenticated and editing %}
-            <a href="{% url 'edit_detail' colid=collection.id col_slug=collection.slug %}">{{ collection.name }}</a>
-            {% else %}
             <a href="{% url 'detail' colid=collection.id col_slug=collection.slug %}">{{ collection.name }}</a>
-            {% endif %}
             <small class="muted">
                 {% for name in collection.courtesy %}
                     {{ name }}
@@ -140,18 +134,18 @@
     {%endif%}
   </div>
   <div class="col-2">
-  {% include "library_collection/_navbar_campus.html" with edit_this='edit_collections' this='collections' %}
+  {% include "library_collection/_navbar_campus.html" with this='collections' %}
   {% if ready_for_publication_facets %}
-    {% include "library_collection/_navbar_published.html" with edit_this='edit_collections' this='collections' %}
+    {% include "library_collection/_navbar_published.html" with this='collections' %}
   {% endif %}
   {% if solr_count_lookups %}
-    {% include "library_collection/_navbar_solr_count.html" with edit_this='edit_collections' this='collections' %}
+    {% include "library_collection/_navbar_solr_count.html" with this='collections' %}
   {% endif %}
   {% if harvest_types %}
-    {% include "library_collection/_navbar_harvest_type.html" with edit_this='edit_collections' this='collections' %}
+    {% include "library_collection/_navbar_harvest_type.html" with this='collections' %}
   {% endif %}
   {% if mapper_types %}
-    {% include "library_collection/_navbar_mapper_type.html" with edit_this='edit_collections' this='collections' %}
+    {% include "library_collection/_navbar_mapper_type.html" with this='collections' %}
   {% endif %}
     <h4>Limit by Merritt</h4>
     <div class="nav-collapse mb-3">

--- a/library_collection/templates/library_collection/repository_collection_list.html
+++ b/library_collection/templates/library_collection/repository_collection_list.html
@@ -5,12 +5,10 @@
 {% block content %}
 <div class="row">
   <div class="col-8">
-    {% if user.is_authenticated and editing %}
-      <form action="{% url 'edit_collections' %}" method="post">
-        {% csrf_token %}
-        <button type="submit" name="new" value="true" class="btn btn-secondary"><i class="icon-plus"></i> Add new Collection</button>
-      </form>
-    {% endif %}
+    <form action="{% url 'collections' %}" method="post">
+      {% csrf_token %}
+      <button type="submit" name="new" value="true" class="btn btn-secondary"><i class="icon-plus"></i> Add new Collection</button>
+    </form>
 
     <div class="card bg-light" style="margin-bottom: 20px">
       <div class="card-body">
@@ -40,11 +38,7 @@
           {% for collection in collections %}
           <tr>
             <td>
-              {% if user.is_authenticated and editing %}
-              <a href="{% url 'edit_detail' colid=collection.id col_slug=collection.slug %}">{{ collection.name }}</a>
-              {% else %}
               <a href="{% url 'detail' colid=collection.id col_slug=collection.slug %}">{{ collection.name }}</a>
-              {% endif %}
               <small class="muted">
                   {% for name in collection.courtesy %}
                       {{ name }}
@@ -103,7 +97,7 @@
     {%endif%}
   </div>
   <div class="col-2">
-  {% include "library_collection/_navbar_harvest_type2.html" with edit_this='edit_collections' this='repository_collections' %}
+  {% include "library_collection/_navbar_harvest_type2.html" with this='repository_collections' %}
   </div>
 </div>
 {% endblock content %}

--- a/library_collection/templates/library_collection/repository_list.html
+++ b/library_collection/templates/library_collection/repository_list.html
@@ -29,18 +29,16 @@
 {% block content %}
 <div class="row">
   <div class="col-8">
-    {% if user.is_authenticated and editing %}
-        <form action="{% url 'edit_repositories' %}" method="post">
-          {% csrf_token %}
-          <button type="submit" name="edit" value="true" class="btn btn-secondary mb-3"><i class="icon-plus"></i> Add new Unit</button>
-        </form>
-    {% endif %}
+      <form action="{% url 'repositories' %}" method="post">
+        {% csrf_token %}
+        <button type="submit" name="edit" value="true" class="btn btn-secondary mb-3"><i class="icon-plus"></i> Add new Unit</button>
+      </form>
 
     {{ repositories.count }} Units
     <table class="table table-bordered table-striped">
       <tbody>
         {% if edit %}
-          <form action="{% url 'edit_repositories' %}" method="post">
+          <form action="{% url 'repositories' %}" method="post">
             {% csrf_token %}
             <tr>
               <td class="form-inline">
@@ -55,7 +53,7 @@
                   {% endfor %}
                 </select>
                 <button type="submit" class="btn btn-primary ml-sm-2 mr-sm-2"><i class="icon-ok icon-white"></i> Save</button>
-                <a href="{% url 'edit_repositories' %}" class="btn btn-secondary"><i class="icon-ban-circle"></i> Cancel</a>
+                <a href="{% url 'repositories' %}" class="btn btn-secondary"><i class="icon-ban-circle"></i> Cancel</a>
               </td>
             </tr>
           </form>
@@ -76,7 +74,7 @@
     </table>
   </div>
   <div class="col-2">
-  {% include "library_collection/_navbar_campus.html" with edit_this="edit_repositories" this="repositories"%}
+  {% include "library_collection/_navbar_campus.html" with this="repositories"%}
   </div>
 </div>
 {% endblock content %}

--- a/library_collection/tests.py
+++ b/library_collection/tests.py
@@ -548,6 +548,19 @@ class TastyPieAPITest(TestCase):
         response = self.client.get(self.url_api)
         self.assertContains(response, 'collection')
 
+    def test_api_access_with_logged_in_user(self):
+        '''Logged-in users should be able to access Tastypie API resources.'''
+        user = User.objects.create_user(
+            username='apiuser', email='apiuser@example.com', password='fake')
+        user.is_active = True
+        user.save()
+        self.client.force_login(user)
+
+        url_collection = self.url_api + 'collection/?limit=1&format=json'
+        response = self.client.get(url_collection)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'objects')
+
     def testDataInApiFeed(self):
         '''Test that the required data elements appear in the api'''
         url_collection = self.url_api + 'collection/?limit=200&format=json'

--- a/library_collection/tests.py
+++ b/library_collection/tests.py
@@ -867,7 +867,7 @@ class EditViewTestCase(TestCase):
 
 
     def testRootView(self):
-        url = reverse('edit_collections')
+        url = reverse('collections')
         response = self.client.get(url, HTTP_AUTHORIZATION=self.http_auth)
         self.assertTemplateUsed(response, 'base.html')
         self.assertTemplateUsed(response,
@@ -879,7 +879,7 @@ class EditViewTestCase(TestCase):
             '/5/1937-yolo-county-aerial-photographs-this-collectio/')
 
     def testUCBCollectionView(self):
-        url = reverse('edit_collections', kwargs={'campus_slug': 'UCB', })
+        url = reverse('collections', kwargs={'campus_slug': 'UCB', })
         response = self.client.get(url, HTTP_AUTHORIZATION=self.http_auth)
         self.assertTemplateUsed(response, 'base.html')
         self.assertContains(response, 'Collections')
@@ -888,7 +888,7 @@ class EditViewTestCase(TestCase):
             '/150/wieslander-vegetation-type-maps-photographs-in-192/')
 
     def testRepositoriesView(self):
-        url = reverse('edit_repositories')
+        url = reverse('repositories')
         response = self.client.get(url, HTTP_AUTHORIZATION=self.http_auth)
         self.assertTemplateUsed(response, 'base.html')
         self.assertTemplateUsed(response,
@@ -898,21 +898,21 @@ class EditViewTestCase(TestCase):
         self.assertContains(response, '/edit/')
 
     def testUCBRepositoriesView(self):
-        url = reverse('edit_repositories', kwargs={'campus_slug': 'UCB', })
+        url = reverse('repositories', kwargs={'campus_slug': 'UCB', })
         response = self.client.get(url, HTTP_AUTHORIZATION=self.http_auth)
         self.assertTemplateUsed(response, 'base.html')
         self.assertTemplateUsed(response,
                                 'library_collection/repository_list.html')
         self.assertNotContains(response, 'Mandeville')
         self.assertContains(response, 'Bancroft Library')
-        url_edit_base = reverse('edit_collections')
+        url_edit_base = reverse('collections')
         self.assertContains(response, url_edit_base)
         self.assertContains(response, url_edit_base + 'UCB')
 
     def testCollectionView(self):
         '''Test view of one collection'''
         url = reverse(
-            'edit_detail',
+            'detail',
             kwargs={
                 'colid': 2,
                 'col_slug':
@@ -927,7 +927,7 @@ class EditViewTestCase(TestCase):
     def testCollectionViewForm(self):
         '''Test form for modifying a collection'''
         url = reverse(
-            'edit_detail',
+            'detail',
             kwargs={
                 'colid': 2,
                 'col_slug':
@@ -942,7 +942,7 @@ class EditViewTestCase(TestCase):
     def testCollectionViewFormSubmission(self):
         '''Test form submission to modify a collection'''
         url = reverse(
-            'edit_detail',
+            'detail',
             kwargs={
                 'colid': 2,
                 'col_slug':
@@ -980,7 +980,7 @@ class EditViewTestCase(TestCase):
     def testCollectionViewFormSubmissionEmptyForm(self):
         '''Test form submission to modify a collection with an empty form'''
         url = reverse(
-            'edit_detail',
+            'detail',
             kwargs={
                 'colid': 2,
                 'col_slug':
@@ -995,7 +995,7 @@ class EditViewTestCase(TestCase):
 
     def testCollectionCreateViewForm(self):
         '''Test form to create a new collection'''
-        url = reverse('edit_collections')
+        url = reverse('collections')
         response = self.client.post(
             url, {'new': 'true'}, HTTP_AUTHORIZATION=self.http_auth)
         self.assertTemplateUsed(response,
@@ -1004,7 +1004,7 @@ class EditViewTestCase(TestCase):
 
     def testCollectionCreateViewFormSubmission(self):
         '''Test form submission to create a collection'''
-        url = reverse('edit_collections')
+        url = reverse('collections')
         response = self.client.post(
             url, {
                 'appendix': 'B',
@@ -1029,7 +1029,7 @@ class EditViewTestCase(TestCase):
 
     def testCollectionCreateViewFormSubmissionInvalid(self):
         '''Test form submission to create a collection'''
-        url = reverse('edit_collections')
+        url = reverse('collections')
         response = self.client.post(
             url, {'appendix': 'B',
                   'name': 'new collection 2'},
@@ -1052,7 +1052,7 @@ class EditViewTestCase(TestCase):
 
     def testCollectionCreateViewFormSubmissionEmptyForm(self):
         '''Test form submission to create an empty collection'''
-        url = reverse('edit_collections')
+        url = reverse('collections')
         response = self.client.post(
             url, {'name': ''}, HTTP_AUTHORIZATION=self.http_auth)
         self.assertTemplateUsed(response,
@@ -1061,7 +1061,7 @@ class EditViewTestCase(TestCase):
 
     def testRepositoryCreateViewForm(self):
         '''Test form to create a new repository'''
-        url = reverse('edit_repositories')
+        url = reverse('repositories')
         response = self.client.post(
             url, {'edit': 'true'}, HTTP_AUTHORIZATION=self.http_auth)
         self.assertTemplateUsed(response,
@@ -1070,7 +1070,7 @@ class EditViewTestCase(TestCase):
 
     def testRepositoryCreateViewFormSubmission(self):
         '''Test form submission to create a repository'''
-        url = reverse('edit_repositories')
+        url = reverse('repositories')
         response = self.client.post(
             url, {'name': 'new repository',
                   'campuses': ['1', '4']},
@@ -1086,7 +1086,7 @@ class EditViewTestCase(TestCase):
 
     def testRepositoryCreateViewFormSubmissionEmptyForm(self):
         '''Test form submission to create an empty repository'''
-        url = reverse('edit_repositories')
+        url = reverse('repositories')
         response = self.client.post(
             url, {'name': ''}, HTTP_AUTHORIZATION=self.http_auth)
         self.assertTemplateUsed(response,
@@ -1191,7 +1191,7 @@ class NewUserTestCase(TestCase):
         # http_auth = 'basic ' + 'bogus_new_user:bogus_new_user'.encode('base64')
         http_auth = 'basic ' + b64encode('bogus_new_user:bogus_new_user'.encode()).decode()
 
-        url = reverse('edit_collections')
+        url = reverse('collections')
         response = self.client.get(url, HTTP_AUTHORIZATION=http_auth)
         self.assertTemplateUsed(
             response, 'library_collection/verification_required.html')

--- a/library_collection/urls.py
+++ b/library_collection/urls.py
@@ -1,44 +1,13 @@
-from django.conf.urls import include, url
-from django.views.generic import TemplateView
-from library_collection.feeds import AllFeed
+from django.conf.urls import url
 from library_collection import views
 
-from tastypie.api import Api
-from library_collection.api import CollectionResource
-from library_collection.api import CampusResource
-from library_collection.api import RepositoryResource
-from library_collection.api import RikoltiCollectionResource
-from library_collection.api import RikoltiFetcherResource
-from library_collection.api import RikoltiMapperResource
-
-v1_api = Api(api_name='v1')
-v1_api.register(CollectionResource())
-v1_api.register(CampusResource())
-v1_api.register(RepositoryResource())
-v1_api.register(RikoltiCollectionResource())
-v1_api.register(RikoltiFetcherResource())
-v1_api.register(RikoltiMapperResource())
-
 urlpatterns = [
-    # Examples:
-    url(r'^$', views.collections, name='collections'),
-    url(r'^edit/$', views.edit_collections, name='edit_collections'),
-    url(r'rss$', AllFeed()),
-    #url(r'',),
-    url(r'^api/', include(v1_api.urls)),
-    url(r'^edit/repositories/$', views.edit_repositories, name='edit_repositories'),
-    url(r'^edit/about/$', views.edit_about, name='edit_about'),
-    url(r'^edit/(?P<campus_slug>UC\w*)/repositories/$', views.edit_repositories, name='edit_repositories'),
-    url(r'^edit/(?P<campus_slug>UC.*)/$', views.edit_collections, name='edit_collections'),
-    url(r'^edit/(?P<colid>\d*)/(?P<col_slug>.*)/$', views.edit_details, name='edit_detail'),
-    url(r'^edit/(?P<colid>\d*)/$', views.edit_details_by_id, name='edit_detail'),
-    url(r'^repositories/$', views.repositories, name='repositories'),
-    # url(r'^repositories/(?P<repository_slug>', views.repositories, name='repositories'),
-    url(r'^about/$', views.about, name='about'),
-    url(r'^(?P<campus_slug>UC.*)/repositories/$', views.repositories, name='repositories'),
-    url(r'^(?P<campus_slug>UC.*)/$', views.collections, name='collections'),
-    url(r'^(?P<colid>\d*)/(?P<col_slug>.*)/$', views.details, name='detail'),
-    url(r'^(?P<colid>\d*)/$', views.details_by_id, name='detail'),
+    url(r'^collections/$', views.edit_collections, name='collections'),
+    url(r'^repositories/$', views.edit_repositories, name='repositories'),
+    url(r'^(?P<campus_slug>UC.*)/repositories/$', views.edit_repositories, name='repositories'),
+    url(r'^(?P<campus_slug>UC.*)/$', views.edit_collections, name='collections'),
+    url(r'^(?P<colid>\d*)$', views.edit_details, name='detail'),
+    url(r'^(?P<colid>\d*)/(?P<col_slug>.*)$', views.edit_details, name='detail'),
     url(r'^repository/(?P<repoid>\d*)/$', views.repository_by_id, name='repository_collections'),
     url(r'^repository/(?P<repoid>\d*)/(?P<repo_slug>.*)/$', views.repository_collections, name='repository_collections'),
 ]

--- a/library_collection/urls.py
+++ b/library_collection/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 from library_collection import views
 
 urlpatterns = [
+    url(r'^$', views.about),
     url(r'^collections/$', views.edit_collections, name='collections'),
     url(r'^repositories/$', views.edit_repositories, name='repositories'),
     url(r'^(?P<campus_slug>UC.*)/repositories/$', views.edit_repositories, name='repositories'),

--- a/library_collection/views.py
+++ b/library_collection/views.py
@@ -140,6 +140,8 @@ def _get_direct_navigate_page_links(get_qd, page_number, num_pages, total_displa
     return previous_page_qs, next_page_qs, previous_group_start, next_group_start
 
 # collections in a repository
+@login_required
+@verification_required
 def repository_collections(request, repoid=None, repo_slug=None):
     page = request.GET.get('page')
     harvest_type = request.GET.get('harvest_type', '')
@@ -399,6 +401,8 @@ def edit_details(request, colid=None, col_slug=None, error=None):
         )
 
 # view for collection details
+@login_required
+@verification_required
 def details(request, colid=None, col_slug=None):
     collection = get_object_or_404(Collection, pk=colid)
     # if the collection id matches, but the slug does not, redirect (for seo)
@@ -416,13 +420,6 @@ def details(request, colid=None, col_slug=None):
 
 @login_required
 @verification_required
-def edit_details_by_id(request, colid):
-    return details_by_id(request, colid)
-
-def details_by_id(request, colid):
-    collection = get_object_or_404(Collection, pk=colid)
-    return redirect(collection, permanent=True)
-
 def repository_by_id(request, repoid):
     repository = get_object_or_404(Repository, pk=repoid)
     return redirect(repository, permanent=True)
@@ -486,6 +483,8 @@ def edit_repositories(request, campus_slug=None, error=None):
     
     return repositories(request, campus_slug)
 
+@login_required
+@verification_required
 def repositories(request, campus_slug=None):
     '''View of repositories, for whole collection or just single campus'''
     campus = None
@@ -515,10 +514,6 @@ def repositories(request, campus_slug=None):
             },
     )
 
-@login_required
-@verification_required
-def edit_about(request):
-    return about(request)
 
 def about(request):
     return render(request, 

--- a/shibboleth/etc/shibd.logger
+++ b/shibboleth/etc/shibd.logger
@@ -45,14 +45,14 @@ log4j.ownAppenders.Shibboleth-TRANSACTION=true
 # define the appenders
 
 log4j.appender.shibd_log=org.apache.log4j.RollingFileAppender
-log4j.appender.shibd_log.fileName=/home/registry/servers/shibboleth/log/shibd.log
+log4j.appender.shibd_log.fileName=/registry/servers/shibboleth/log/shibd.log
 log4j.appender.shibd_log.maxFileSize=1000000
 log4j.appender.shibd_log.maxBackupIndex=10
 log4j.appender.shibd_log.layout=org.apache.log4j.PatternLayout
 log4j.appender.shibd_log.layout.ConversionPattern=%d{%Y-%m-%d %H:%M:%S} %p %c %x: %m%n
 
 log4j.appender.warn_log=org.apache.log4j.RollingFileAppender
-log4j.appender.warn_log.fileName=/home/registry/servers/shibboleth/log/shibd_warn.log
+log4j.appender.warn_log.fileName=/registry/servers/shibboleth/log/shibd_warn.log
 log4j.appender.warn_log.maxFileSize=1000000
 log4j.appender.warn_log.maxBackupIndex=10
 log4j.appender.warn_log.layout=org.apache.log4j.PatternLayout
@@ -60,13 +60,13 @@ log4j.appender.warn_log.layout.ConversionPattern=%d{%Y-%m-%d %H:%M:%S} %p %c %x:
 log4j.appender.warn_log.threshold=WARN
 
 log4j.appender.tran_log=org.apache.log4j.RollingFileAppender
-log4j.appender.tran_log.fileName=/home/registry/servers/shibboleth/log/transaction.log
+log4j.appender.tran_log.fileName=/registry/servers/shibboleth/log/transaction.log
 log4j.appender.tran_log.maxFileSize=1000000
 log4j.appender.tran_log.maxBackupIndex=20
 log4j.appender.tran_log.layout=org.apache.log4j.PatternLayout
 log4j.appender.tran_log.layout.ConversionPattern=%d{%Y-%m-%d %H:%M:%S}|%c|%m%n
 
 log4j.appender.sig_log=org.apache.log4j.FileAppender
-log4j.appender.sig_log.fileName=/home/registry/servers/shibboleth/log/signature.log
+log4j.appender.sig_log.fileName=/registry/servers/shibboleth/log/signature.log
 log4j.appender.sig_log.layout=org.apache.log4j.PatternLayout
 log4j.appender.sig_log.layout.ConversionPattern=%m

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,11 +68,7 @@
       <div class="row no-gutters">
         <div class="col-8" >
           <h3 class="logo">
-            {% if user.is_authenticated and editing %}
-            <a href="{% url 'edit_collections' %}">
-            {% else %}
-            <a href="{% url 'collections' %}">
-            {% endif %}
+            <a href="{% url 'about' %}">
               UCLDC Collection Registry
             </a>
           </h3>
@@ -81,8 +77,8 @@
           <span class="float-right">
             {% if user.is_authenticated %}
             Welcome {{user}}
-            {%else%}
-            <!-- <a href="/edit{{current_path}}" title="Login to edit collections or repositories">Edit</a> -->
+            {% else %}
+            <a href="{% url 'login' %}" title="Login to edit collections or repositories">Login</a>
             {%endif%}
           </span>
         </div>
@@ -98,40 +94,20 @@
       <ul class="nav nav-tabs col-12 mb-3 registry-nav" style="margin-left: 0px;">
         <li class="nav-item">
           {%if campus %}
-            {% if user.is_authenticated and editing %}
-            <a class="nav-link{% if active_tab == 'collection' %} active{%endif%}" href="{%url 'edit_collections' campus_slug=campus.slug %}">Collections</a>
-            {% else %}
-            <a class="nav-link{% if active_tab == 'collection' %} active{%endif%}" href="{%url 'collections' campus_slug=campus.slug %}">Collections</a>
-            {% endif %}
+            <a class="nav-link{% if active_tab == 'collection' or next == '/collections/' %} active{%endif%}" href="{%url 'collections' campus_slug=campus.slug %}">Collections</a>
           {% else %}
-            {% if user.is_authenticated and editing %}
-            <a class="nav-link{% if active_tab == 'collection' %} active{%endif%}" href="{%url 'edit_collections' %}">Collections</a>
-            {% else %}
-            <a class="nav-link{% if active_tab == 'collection' %} active{%endif%}" href="{%url 'collections' %}">Collections</a>
-            {% endif %}
+            <a class="nav-link{% if active_tab == 'collection' or next == '/collections/' %} active{%endif%}" href="{%url 'collections' %}">Collections</a>
           {% endif %}
         </li>
         <li class="nav-item">
           {%if campus %}
-            {% if user.is_authenticated and editing %}
-            <a class="nav-link{% if active_tab == 'repositories' %} active{%endif%}" href="{%url 'edit_repositories' campus_slug=campus.slug %}">Units</a>
-            {% else %}
-            <a class="nav-link{% if active_tab == 'repositories' %} active{%endif%}" href="{%url 'repositories' campus_slug=campus.slug %}">Units</a>
-            {% endif %}
+            <a class="nav-link{% if active_tab == 'repositories' or next == '/repositories/' %} active{%endif%}" href="{%url 'repositories' campus_slug=campus.slug %}">Units</a>
           {% else %}
-            {% if user.is_authenticated and editing %}
-            <a class="nav-link{% if active_tab == 'repositories' %} active{%endif%}" href="{%url 'edit_repositories' %}">Units</a>
-            {% else %}
-            <a class="nav-link{% if active_tab == 'repositories' %} active{%endif%}" href="{%url 'repositories' %}">Units</a>
-            {% endif %}
+            <a class="nav-link{% if active_tab == 'repositories' or next == '/repositories/' %} active{%endif%}" href="{%url 'repositories' %}">Units</a>
           {% endif %}
         </li>
         <li class="nav-item">
-          {% if user.is_authenticated and editing %}
-          <a class="nav-link{% if active_tab == 'about' %} active{%endif%}" href="{%url 'edit_about' %}">About</a>
-          {% else %}
           <a class="nav-link{% if active_tab == 'about' %} active{%endif%}" href="{%url 'about' %}">About</a>
-          {% endif %}
         </li>
         <li class="nav-item">
           {% if active_tab == 'exhibitions' %}
@@ -159,11 +135,7 @@
       <div class="col-1"><img src="{% static 'images/uc_seal.gif' %}" alt="University of California"></div>
       <div class="col-3">Powered by the <a href="http://www.cdlib.org" target="_blank">California&#160;Digital&#160;Library</a></div>
       <div class="col-1">
-        {% if user.is_authenticated and editing %}
-        <a href="{%url 'edit_about' %}">Terms</a>
-        {% else %}
         <a href="{%url 'about' %}">Terms</a>
-        {% endif %}
       </div>
       <div class="col-1">
         <a href="http://www.cdlib.org/about/privacy.html" target="_blank">Privacy</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,7 +78,7 @@
             {% if user.is_authenticated %}
             Welcome {{user}}
             {% else %}
-            <a href="{% url 'login' %}" title="Login to edit collections or repositories">Login</a>
+            <a href="{% url 'collections' %}" title="Login to edit collections or repositories">Login</a>
             {%endif%}
           </span>
         </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
     <link href="{% static 'chosen/css/chosen.css' %}" rel="stylesheet"/>
     <style>
       body { font-family: Arial, Helvetica, sans-serif;
-       color: #7C7E7F;
+       /* color: #7C7E7F; */
       }
       h3.logo { 
         background: 
@@ -131,14 +131,17 @@
       <!-- <div class="col-3 float-right">
         Copyright © 2013 UC Regents.<br/> All rights reserved.
       </div> -->
-      <div class="col-5">Copyright © {% now "Y" %} The&#160;Regents of The University&#160;of&#160;California</div>
-      <div class="col-1"><img src="{% static 'images/uc_seal.gif' %}" alt="University of California"></div>
-      <div class="col-3">Powered by the <a href="http://www.cdlib.org" target="_blank">California&#160;Digital&#160;Library</a></div>
+      <!-- <div class="col-5">Copyright © {% now "Y" %} The&#160;Regents of The University&#160;of&#160;California</div> -->
+      <!-- <div class="col-1"><img src="{% static 'images/uc_seal.gif' %}" alt="University of California"></div> -->
+      <div class="col-5">Powered by the <a href="http://www.cdlib.org">California&#160;Digital&#160;Library</a></div>
       <div class="col-1">
-        <a href="{%url 'about' %}">Terms</a>
+        <a href="https://calisphere.org/privacy/">Privacy Statement</a>
       </div>
       <div class="col-1">
-        <a href="http://www.cdlib.org/about/privacy.html" target="_blank">Privacy</a>
+        <a href="https://www.cdlib.org/about/accessibility.html">Accessibility</a>
+      </div>
+      <div class="col-1">
+        <a href="https://calisphere.org/contact/">Contact Us</a>
       </div>
     </div>
     

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
       body { font-family: Arial, Helvetica, sans-serif;
        /* color: #7C7E7F; */
       }
-      h3.logo { 
+      nav.logo { 
         background: 
           transparent 
           url("{% static 'images/ucldc-registry.png' %}") 
@@ -26,7 +26,7 @@
         border: 0;
         margin: 20px 0;
       }
-      h3.logo a {
+      nav.logo a {
         display: block;
         width: 370px;
         height: 56px;
@@ -67,11 +67,11 @@
     <div class="container-fluid" style="padding: 0 20px;">
       <div class="row no-gutters">
         <div class="col-8" >
-          <h3 class="logo">
+          <nav class="logo">
             <a href="{% url 'about' %}">
               UCLDC Collection Registry
             </a>
-          </h3>
+          </nav>
         </div>
         <div class="col-4">
           <span class="float-right">

--- a/templates/base.html
+++ b/templates/base.html
@@ -134,13 +134,13 @@
       <!-- <div class="col-5">Copyright © {% now "Y" %} The&#160;Regents of The University&#160;of&#160;California</div> -->
       <!-- <div class="col-1"><img src="{% static 'images/uc_seal.gif' %}" alt="University of California"></div> -->
       <div class="col-5">Powered by the <a href="http://www.cdlib.org">California&#160;Digital&#160;Library</a></div>
-      <div class="col-1">
+      <div class="col-2">
         <a href="https://calisphere.org/privacy/">Privacy Statement</a>
       </div>
-      <div class="col-1">
+      <div class="col-2">
         <a href="https://www.cdlib.org/about/accessibility.html">Accessibility</a>
       </div>
-      <div class="col-1">
+      <div class="col-2">
         <a href="https://calisphere.org/contact/">Contact Us</a>
       </div>
     </div>


### PR DESCRIPTION
Contributors can still login and access the /edit pages via shibboleth
CDL Staff can still login and access the /admin pages via shibboleth
Anyone logged in via shibboleth can access the /api pages
We can also bypass shibboleth login and access the /api pages via token authentication

To deploy without disruption to services: 
1) pull this codebase in to prod
2) migrate: `python manage.py migrate`
3) create calisphere and rikolti users in the admin interface and create API keys for them
4) put the API keys in calisphere and rikolti
5) update shibboleth logging config & apache config
6) restart shibboleth & apache: `monit restart shibd` `monit restart http`